### PR TITLE
Fix debug buffer overflow

### DIFF
--- a/src/debug.h
+++ b/src/debug.h
@@ -14,6 +14,7 @@ extern bool debug_enabled;
 	do {                                                             \
 		debug_start();                                               \
 		debug_idx += sprintf(&debug_buffer[debug_idx], __VA_ARGS__); \
+		debug_idx += sprintf(&debug_buffer[debug_idx], "\n");        \
 		debug_end();                                                 \
 	} while (0)
 


### PR DESCRIPTION
It was possible for the debug output to overrun the buffer. The buffer keeps the last 10 lines, but doesn't have provisions for a single really long line taking up all the space.

Found in part with the CodeHawk C analyzer.